### PR TITLE
Report errors back to trafficlight. 

### DIFF
--- a/trafficlight_adapter_appium/action/system.py
+++ b/trafficlight_adapter_appium/action/system.py
@@ -1,13 +1,21 @@
+import logging
+
 from trafficlight_adapter_appium.response import Response
 from trafficlight_adapter_appium.request import Request
 from trafficlight_adapter_appium.action import ActionException
 import time
+import logging
+
+logger = logging.getLogger(__name__)
 
 def idle(driver, request: Request) -> Response:
     duration = int(request.data['delay'])
     time.sleep(duration / 1000)
     return Response({})
 
+def exit(driver, request: Request) -> Response:
+    logger.info("Closing down adapter on server request")
+    return Response({})
 
 def advance_clock(driver, request: Request) -> Response:
         time_ms = request.data['milliseconds']


### PR DESCRIPTION
Attempt to upload last page context from driver on failure.

We should additionally pull and upload screenshots and logs from the appium provider; but that requires per-service data, so leaving that as an exercise for another day.